### PR TITLE
Use java conventions for method names

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,8 +58,8 @@ publishing {
 }
 
 bintray {
-    user = bintray_user
-    key = bintray_api_key
+    user = hasProperty('bintray_user') ? bintray_user : ''
+    key = key = hasProperty('bintray_api_key') ? bintray_api_key : ''
 
     publications = ['mavenJava']
     dryRun = false //Whether to run this as dry-run, without deploying

--- a/src/main/java/org/pybee/cassowary/AbstractConstraint.java
+++ b/src/main/java/org/pybee/cassowary/AbstractConstraint.java
@@ -28,7 +28,7 @@ public abstract class AbstractConstraint
         _weight = 1.0;
     }
 
-    public abstract Expression expression();
+    public abstract Expression getExpression();
 
     public boolean isEditConstraint()
     {
@@ -50,19 +50,19 @@ public abstract class AbstractConstraint
         return false;
     }
 
-    public Strength strength()
+    public Strength getStrength()
     {
         return _strength;
     }
 
-    public double weight()
+    public double getWeight()
     {
         return _weight;
     }
 
     public String toString()
     {
-        return _strength + " {" + weight() + "} (" + expression();
+        return _strength + " {" + getWeight() + "} (" + getExpression();
     }
 
     public void setAttachedObject(Object o)

--- a/src/main/java/org/pybee/cassowary/AbstractVariable.java
+++ b/src/main/java/org/pybee/cassowary/AbstractVariable.java
@@ -28,7 +28,7 @@ public abstract class AbstractVariable
         iVariableNumber++;
     }
 
-    public String name()
+    public String getName()
     {
         return _name;
     }

--- a/src/main/java/org/pybee/cassowary/Constraint.java
+++ b/src/main/java/org/pybee/cassowary/Constraint.java
@@ -14,7 +14,7 @@ public class Constraint extends AbstractConstraint
             this._value = value;
         }
 
-        public int value() {
+        public int getValue() {
             return _value;
         }
 
@@ -249,7 +249,7 @@ public class Constraint extends AbstractConstraint
         this(cle, op_enum, clv, Strength.REQUIRED, 1.0);
     }
 
-    public Expression expression()
+    public Expression getExpression()
     {
         return _expression;
     }

--- a/src/main/java/org/pybee/cassowary/DummyVariable.java
+++ b/src/main/java/org/pybee/cassowary/DummyVariable.java
@@ -17,7 +17,7 @@ class DummyVariable extends AbstractVariable
 
     public String toString()
     {
-        return "[" + name() + ":dummy]";
+        return "[" + getName() + ":dummy]";
     }
 
     public boolean isDummy()

--- a/src/main/java/org/pybee/cassowary/EditConstraint.java
+++ b/src/main/java/org/pybee/cassowary/EditConstraint.java
@@ -12,7 +12,7 @@ public class EditConstraint extends AbstractConstraint
     {
         super(strength, weight);
         _variable = var;
-        _expression = new Expression(_variable, -1.0, _variable.value());
+        _expression = new Expression(_variable, -1.0, _variable.getValue());
     }
 
     public EditConstraint(Variable var, Strength strength)
@@ -26,12 +26,12 @@ public class EditConstraint extends AbstractConstraint
         _variable = var;
     }
 
-    public Variable variable()
+    public Variable getVariable()
     {
         return _variable;
     }
 
-    public Expression expression()
+    public Expression getExpression()
     {
         return _expression;
     }

--- a/src/main/java/org/pybee/cassowary/EditInfo.java
+++ b/src/main/java/org/pybee/cassowary/EditInfo.java
@@ -23,27 +23,27 @@ class EditInfo {
         _i = i;
     }
 
-    public int index()
+    public int getIndex()
     {
         return _i;
     }
 
-    public AbstractConstraint constraint()
+    public AbstractConstraint getConstraint()
     {
         return _cn;
     }
 
-    public AbstractVariable clvEditPlus()
+    public AbstractVariable getClvEditPlus()
     {
         return _clvEditPlus;
     }
 
-    public AbstractVariable clvEditMinus()
+    public AbstractVariable getClvEditMinus()
     {
         return _clvEditMinus;
     }
 
-    public double prevEditConstant()
+    public double getPrevEditConstant()
     {
         return _prevEditConstant;
     }

--- a/src/main/java/org/pybee/cassowary/Expression.java
+++ b/src/main/java/org/pybee/cassowary/Expression.java
@@ -148,11 +148,11 @@ public class Expression
     // expression.
     public final Expression addExpression(Expression expr, double n, AbstractVariable subject, Tableau solver)
     {
-        incrementConstant(n * expr.constant());
+        incrementConstant(n * expr.getConstant());
 
-        for (AbstractVariable clv: expr.terms().keySet())
+        for (AbstractVariable clv: expr.getTerms().keySet())
         {
-            double coeff = expr.terms().get(clv);
+            double coeff = expr.getTerms().get(clv);
             addVariable(clv, coeff*n, subject, solver);
         }
         return this;
@@ -161,11 +161,11 @@ public class Expression
     // Add n*expr to this expression from another expression expr.
     public final Expression addExpression(Expression expr, double n)
     {
-        incrementConstant(n * expr.constant());
+        incrementConstant(n * expr.getConstant());
 
-        for (AbstractVariable clv: expr.terms().keySet())
+        for (AbstractVariable clv: expr.getTerms().keySet())
         {
-            double coeff = expr.terms().get(clv);
+            double coeff = expr.getTerms().get(clv);
             addVariable(clv, coeff*n);
         }
         return this;
@@ -256,7 +256,7 @@ public class Expression
     {
         if (isConstant())
         {
-            throw new InternalError("anyPivotableVariable called on a constant");
+            throw new InternalError("anyPivotableVariable called on a getConstant");
         }
 
         for (AbstractVariable clv: _terms.keySet())
@@ -281,11 +281,11 @@ public class Expression
     public final void substituteOut(AbstractVariable var, Expression expr, AbstractVariable subject, Tableau solver)
     {
         double multiplier = ((Double) _terms.remove(var)).doubleValue();
-        incrementConstant(multiplier * expr.constant());
+        incrementConstant(multiplier * expr.getConstant());
 
-        for (AbstractVariable clv: expr.terms().keySet())
+        for (AbstractVariable clv: expr.getTerms().keySet())
         {
-            double coeff = ((Double) expr.terms().get(clv)).doubleValue();
+            double coeff = ((Double) expr.getTerms().get(clv)).doubleValue();
             Double d_old_coeff = (Double) _terms.get(clv);
             if (d_old_coeff != null)
             {
@@ -370,17 +370,17 @@ public class Expression
         }
     }
 
-    public final double constant()
+    public final double getConstant()
     {
         return _constant;
     }
 
-    public final void set_constant(double c)
+    public final void setConstant(double c)
     {
         _constant = c;
     }
 
-    public final Hashtable<AbstractVariable, Double> terms()
+    public final Hashtable<AbstractVariable, Double> getTerms()
     {
         return _terms;
     }

--- a/src/main/java/org/pybee/cassowary/ObjectiveVariable.java
+++ b/src/main/java/org/pybee/cassowary/ObjectiveVariable.java
@@ -15,7 +15,7 @@ class ObjectiveVariable extends AbstractVariable
 
     public String toString()
     {
-        return "[" + name() + ":obj]";
+        return "[" + getName() + ":obj]";
     }
 
     public boolean isExternal()

--- a/src/main/java/org/pybee/cassowary/SimplexSolver.java
+++ b/src/main/java/org/pybee/cassowary/SimplexSolver.java
@@ -142,7 +142,7 @@ public class SimplexSolver extends Tableau
             AbstractVariable clvEplus = (AbstractVariable) eplus_eminus.elementAt(0);
             AbstractVariable clvEminus = (AbstractVariable) eplus_eminus.elementAt(1);
             _editVarMap.put(
-                cnEdit.variable(),
+                cnEdit.getVariable(),
                 new EditInfo(cnEdit, clvEplus, clvEminus, prevEConstant.doubleValue(), i)
             );
         }
@@ -200,7 +200,7 @@ public class SimplexSolver extends Tableau
             throws InternalError, ConstraintNotFound
     {
         EditInfo cei = _editVarMap.get(v);
-        AbstractConstraint cn = cei.constraint();
+        AbstractConstraint cn = cei.getConstraint();
         removeConstraint(cn);
         return this;
     }
@@ -252,7 +252,7 @@ public class SimplexSolver extends Tableau
             {
                 Variable v = e.nextElement();
                 EditInfo cei = _editVarMap.get(v);
-                if (cei.index() >= n)
+                if (cei.getIndex() >= n)
                 {
                     removeEditVar(v);
                 }
@@ -311,12 +311,12 @@ public class SimplexSolver extends Tableau
                 final Expression expr = rowExpression(clv);
                 if (expr == null)
                 {
-                    zRow.addVariable(clv, -cn.weight() * cn.strength().value(),
+                    zRow.addVariable(clv, -cn.getWeight() * cn.getStrength().getValue(),
                     _objective, this);
                 }
                 else
                 { // the error variable was in the basis
-                    zRow.addExpression(expr, -cn.weight() * cn.strength().value(),
+                    zRow.addExpression(expr, -cn.getWeight() * cn.getStrength().getValue(),
                     _objective, this);
                 }
             }
@@ -342,7 +342,7 @@ public class SimplexSolver extends Tableau
                     double coeff = expr.coefficientFor(marker);
                     if (coeff < 0.0)
                     {
-                        double r = -expr.constant() / coeff;
+                        double r = -expr.getConstant() / coeff;
                         if (exitVar == null || r < minRatio)
                         {
                             minRatio = r;
@@ -359,7 +359,7 @@ public class SimplexSolver extends Tableau
                     {
                         final Expression expr = rowExpression(v);
                         double coeff = expr.coefficientFor(marker);
-                        double r = expr.constant() / coeff;
+                        double r = expr.getConstant() / coeff;
                         if (exitVar == null || r < minRatio)
                         {
                             minRatio = r;
@@ -421,9 +421,9 @@ public class SimplexSolver extends Tableau
         {
             // assert eVars != null;
             EditConstraint cnEdit = (EditConstraint) cn;
-            Variable clv = cnEdit.variable();
+            Variable clv = cnEdit.getVariable();
             EditInfo cei = _editVarMap.get(clv);
-            AbstractVariable clvEditMinus = cei.clvEditMinus();
+            AbstractVariable clvEditMinus = cei.getClvEditMinus();
             // Variable clvEditPlus = cei.ClvEditPlus();
             // the clvEditPlus is a marker variable that is removed elsewhere
             removeColumn(clvEditMinus);
@@ -469,7 +469,7 @@ public class SimplexSolver extends Tableau
         for (Variable v: _editVarMap.keySet())
         {
             EditInfo cei = _editVarMap.get(v);
-            int i = cei.index();
+            int i = cei.getIndex();
             try
             {
                 if (i < newEditConstants.size())
@@ -520,10 +520,10 @@ public class SimplexSolver extends Tableau
             System.err.println("suggestValue for variable " + v + ", but var is not an edit variable\n");
             throw new CassowaryError();
         }
-        int i = cei.index();
-        AbstractVariable clvEditPlus = cei.clvEditPlus();
-        AbstractVariable clvEditMinus = cei.clvEditMinus();
-        double delta = x - cei.prevEditConstant();
+        int i = cei.getIndex();
+        AbstractVariable clvEditPlus = cei.getClvEditPlus();
+        AbstractVariable clvEditMinus = cei.getClvEditMinus();
+        double delta = x - cei.getPrevEditConstant();
         cei.setPrevEditConstant(x);
         deltaEditConstant(delta, clvEditPlus, clvEditMinus);
         return this;
@@ -569,11 +569,11 @@ public class SimplexSolver extends Tableau
             throws InternalError
     {
         if (!FContainsVariable(v)) {
-            v.change_value(n);
+            v.changeValue(n);
             return this;
         }
 
-        if (!Util.approx(n, v.value())) {
+        if (!Util.approx(n, v.getValue())) {
             addEditVar(v);
             beginEdit();
             try {
@@ -672,7 +672,7 @@ public class SimplexSolver extends Tableau
 
         Expression azTableauRow = rowExpression(az);
 
-        if (!Util.approx(azTableauRow.constant(), 0.0))
+        if (!Util.approx(azTableauRow.getConstant(), 0.0))
         {
             removeRow(az);
             removeColumn(av);
@@ -748,7 +748,7 @@ public class SimplexSolver extends Tableau
         boolean foundUnrestricted = false;
         boolean foundNewRestricted = false;
 
-        final Hashtable<AbstractVariable, Double> terms = expr.terms();
+        final Hashtable<AbstractVariable, Double> terms = expr.getTerms();
 
         for (AbstractVariable v: terms.keySet())
         {
@@ -808,7 +808,7 @@ public class SimplexSolver extends Tableau
             }
         }
 
-        if (!Util.approx(expr.constant(), 0.0))
+        if (!Util.approx(expr.getConstant(), 0.0))
         {
             throw new RequiredFailure();
         }
@@ -843,7 +843,7 @@ public class SimplexSolver extends Tableau
         {
             exprPlus.incrementConstant(delta);
 
-            if (exprPlus.constant() < 0.0)
+            if (exprPlus.getConstant() < 0.0)
             {
                 _infeasibleRows.add(plusErrorVar);
             }
@@ -854,7 +854,7 @@ public class SimplexSolver extends Tableau
         if (exprMinus != null)
         {
             exprMinus.incrementConstant(-delta);
-            if (exprMinus.constant() < 0.0)
+            if (exprMinus.getConstant() < 0.0)
             {
                 _infeasibleRows.add(minusErrorVar);
             }
@@ -867,7 +867,7 @@ public class SimplexSolver extends Tableau
             //assert(expr != null, "expr != null" );
             final double c = expr.coefficientFor(minusErrorVar);
             expr.incrementConstant(c * delta);
-            if (basicVar.isRestricted() && expr.constant() < 0.0)
+            if (basicVar.isRestricted() && expr.getConstant() < 0.0)
             {
                 _infeasibleRows.add(basicVar);
             }
@@ -891,11 +891,11 @@ public class SimplexSolver extends Tableau
             Expression expr = rowExpression(exitVar);
             if (expr != null )
             {
-                if (expr.constant() < 0.0)
+                if (expr.getConstant() < 0.0)
                 {
                     double ratio = Double.MAX_VALUE;
                     double r;
-                    Hashtable<AbstractVariable, Double> terms = expr.terms();
+                    Hashtable<AbstractVariable, Double> terms = expr.getTerms();
                     for (AbstractVariable v: terms.keySet())
                     {
                         double c = terms.get(v).doubleValue();
@@ -927,13 +927,13 @@ public class SimplexSolver extends Tableau
     // appropriate weight in the objective function.
     protected final Expression newExpression(AbstractConstraint cn, Vector eplus_eminus, Double prevEConstant)
     {
-        final Expression cnExpr = cn.expression();
-        Expression expr = new Expression(cnExpr.constant());
+        final Expression cnExpr = cn.getExpression();
+        Expression expr = new Expression(cnExpr.getConstant());
         SlackVariable slackVar = new SlackVariable();
         DummyVariable dummyVar = new DummyVariable();
         SlackVariable eminus = new SlackVariable();
         SlackVariable eplus = new SlackVariable();
-        final Hashtable<AbstractVariable, Double> cnTerms = cnExpr.terms();
+        final Hashtable<AbstractVariable, Double> cnTerms = cnExpr.getTerms();
         for (AbstractVariable v: cnTerms.keySet())
         {
             double c = cnTerms.get(v).doubleValue();
@@ -960,7 +960,7 @@ public class SimplexSolver extends Tableau
                 eminus = new SlackVariable(_slackCounter, "em");
                 expr.setVariable(eminus, 1.0);
                 Expression zRow = rowExpression(_objective);
-                double swCoeff = cn.strength().value() * cn.weight();
+                double swCoeff = cn.getStrength().getValue() * cn.getWeight();
                 zRow.setVariable(eminus, swCoeff);
                 insertErrorVar(cn, eminus);
                 noteAddedVariable(eminus, _objective);
@@ -988,7 +988,7 @@ public class SimplexSolver extends Tableau
                 expr.setVariable(eminus, 1.0);
                 _markerVars.put(cn, eplus);
                 Expression zRow = rowExpression(_objective);
-                double swCoeff = cn.strength().value() * cn.weight();
+                double swCoeff = cn.getStrength().getValue() * cn.getWeight();
                 zRow.setVariable(eplus, swCoeff);
                 noteAddedVariable(eplus, _objective);
                 zRow.setVariable(eminus, swCoeff);
@@ -1008,12 +1008,12 @@ public class SimplexSolver extends Tableau
                     // setValue call; since prevEConstant is passed in by reference,
                     // this means the value should be reflected outside this method.
                     // Does this actually matter?
-                    prevEConstant = new Double(cnExpr.constant());
+                    prevEConstant = new Double(cnExpr.getConstant());
                 }
             }
         }
 
-        if (expr.constant() < 0)
+        if (expr.getConstant() < 0)
         {
            expr.multiplyMe(-1);
         }
@@ -1033,7 +1033,7 @@ public class SimplexSolver extends Tableau
         while (true)
         {
             double objectiveCoeff = 0;
-            Hashtable<AbstractVariable, Double> terms = zRow.terms();
+            Hashtable<AbstractVariable, Double> terms = zRow.getTerms();
             for (AbstractVariable v: terms.keySet()) {
                 double c = ((Double) terms.get(v)).doubleValue();
                 if (v.isPivotable() && c < objectiveCoeff)
@@ -1057,7 +1057,7 @@ public class SimplexSolver extends Tableau
                     double coeff = expr.coefficientFor(entryVar);
                     if (coeff < 0.0)
                     {
-                        r = - expr.constant() / coeff;
+                        r = - expr.getConstant() / coeff;
                         if (r < minRatio)
                         {
                             minRatio = r;
@@ -1113,7 +1113,7 @@ public class SimplexSolver extends Tableau
             }
             if (expr != null)
             {
-                expr.set_constant(0.0);
+                expr.setConstant(0.0);
             }
         }
     }
@@ -1137,14 +1137,14 @@ public class SimplexSolver extends Tableau
                 System.err.println("Error: variable" + v + " in _externalParametricVars is basic");
                 continue;
             }
-            v.change_value(0.0);
+            v.changeValue(0.0);
         }
 
         for (AbstractVariable av: _externalRows)
         {
             Variable v = (Variable) av;
             Expression expr = rowExpression(v);
-            v.change_value(expr.constant());
+            v.changeValue(expr.getConstant());
         }
 
         _fNeedsSolving = false;

--- a/src/main/java/org/pybee/cassowary/SlackVariable.java
+++ b/src/main/java/org/pybee/cassowary/SlackVariable.java
@@ -17,7 +17,7 @@ class SlackVariable extends AbstractVariable
 
     public String toString()
     {
-        return "[" + name() + ":slack]";
+        return "[" + getName() + ":slack]";
     }
 
     public boolean isExternal()

--- a/src/main/java/org/pybee/cassowary/StayConstraint.java
+++ b/src/main/java/org/pybee/cassowary/StayConstraint.java
@@ -12,7 +12,7 @@ public class StayConstraint extends AbstractConstraint
     {
         super(strength, weight);
         _variable = var;
-        _expression = new Expression(_variable, -1.0, _variable.value());
+        _expression = new Expression(_variable, -1.0, _variable.getValue());
     }
 
     public StayConstraint(Variable var, Strength strength)
@@ -26,12 +26,12 @@ public class StayConstraint extends AbstractConstraint
         _variable = var;
     }
 
-    public Variable variable()
+    public Variable getVariable()
     {
         return _variable;
     }
 
-    public Expression expression()
+    public Expression getExpression()
     {
         return _expression;
     }

--- a/src/main/java/org/pybee/cassowary/Strength.java
+++ b/src/main/java/org/pybee/cassowary/Strength.java
@@ -14,7 +14,7 @@ public enum Strength
         this._value = value;
     }
 
-    public int value() {
+    public int getValue() {
         return _value;
     }
 

--- a/src/main/java/org/pybee/cassowary/Tableau.java
+++ b/src/main/java/org/pybee/cassowary/Tableau.java
@@ -127,7 +127,7 @@ class Tableau
         // have that variable in their expression
         _rows.put(var, expr);
 
-        for (AbstractVariable clv: expr.terms().keySet())
+        for (AbstractVariable clv: expr.getTerms().keySet())
         {
             insertColVar(clv, var);
             if (clv.isExternal())
@@ -152,7 +152,7 @@ class Tableau
             for (AbstractVariable clv: rows)
             {
                 Expression expr = _rows.get(clv);
-                expr.terms().remove(var);
+                expr.getTerms().remove(var);
             }
         }
 
@@ -174,7 +174,7 @@ class Tableau
         // For each variable in this expression, update
         // the column mapping and remove the variable from the list
         // of rows it is known to be in
-        for (AbstractVariable clv: expr.terms().keySet()) {
+        for (AbstractVariable clv: expr.getTerms().keySet()) {
             Set varset = (Set) _columns.get(clv);
             if (varset != null)
             {
@@ -200,7 +200,7 @@ class Tableau
         {
             Expression row = _rows.get(v);
             row.substituteOut(oldVar, expr, v, this);
-            if (v.isRestricted() && row.constant() < 0.0)
+            if (v.isRestricted() && row.getConstant() < 0.0)
             {
                 _infeasibleRows.add(v);
             }

--- a/src/main/java/org/pybee/cassowary/Util.java
+++ b/src/main/java/org/pybee/cassowary/Util.java
@@ -21,11 +21,11 @@ public class Util {
 
     public static boolean approx(Variable clv, double b)
     {
-        return approx(clv.value(),b);
+        return approx(clv.getValue(),b);
     }
 
     public static boolean approx(double a, Variable clv)
     {
-        return approx(a,clv.value());
+        return approx(a,clv.getValue());
     }
 }

--- a/src/main/java/org/pybee/cassowary/Variable.java
+++ b/src/main/java/org/pybee/cassowary/Variable.java
@@ -77,17 +77,17 @@ public class Variable extends AbstractVariable
 
     public String toString()
     {
-        return "[" + name() + ":" + _value + "]";
+        return "[" + getName() + ":" + _value + "]";
     }
 
     // change the value held -- should *not* use this if the variable is
     // in a solver -- instead use addEditVar() and suggestValue() interface
-    public final double value()
+    public final double getValue()
     {
         return _value;
     }
 
-    public final void set_value(double value)
+    public final void setValue(double value)
     {
         _value = value;
     }
@@ -96,7 +96,7 @@ public class Variable extends AbstractVariable
     // done when the value is changed by the solver
     // may be called when the value hasn't actually changed -- just
     // means the solver is setting the external variable
-    public void change_value(double value)
+    public void changeValue(double value)
     {
         _value = value;
     }

--- a/src/test/java/org/pybee/cassowary/test/RealWorldTests.java
+++ b/src/test/java/org/pybee/cassowary/test/RealWorldTests.java
@@ -211,23 +211,23 @@ public class RealWorldTests {
 
         solver.solve();
 
-        assertEquals(20, nodeHashMap.get("thumb0").get("top").value(), EPSILON);
-        assertEquals(20, nodeHashMap.get("thumb1").get("top").value(), EPSILON);
+        assertEquals(20, nodeHashMap.get("thumb0").get("top").getValue(), EPSILON);
+        assertEquals(20, nodeHashMap.get("thumb1").get("top").getValue(), EPSILON);
 
-        assertEquals(85, nodeHashMap.get("title0").get("top").value(), EPSILON);
-        assertEquals(85, nodeHashMap.get("title1").get("top").value(), EPSILON);
+        assertEquals(85, nodeHashMap.get("title0").get("top").getValue(), EPSILON);
+        assertEquals(85, nodeHashMap.get("title1").get("top").getValue(), EPSILON);
 
-        assertEquals(210, nodeHashMap.get("thumb2").get("top").value(), EPSILON);
-        assertEquals(210, nodeHashMap.get("thumb3").get("top").value(), EPSILON);
+        assertEquals(210, nodeHashMap.get("thumb2").get("top").getValue(), EPSILON);
+        assertEquals(210, nodeHashMap.get("thumb3").get("top").getValue(), EPSILON);
 
-        assertEquals(275, nodeHashMap.get("title2").get("top").value(), EPSILON);
-        assertEquals(275, nodeHashMap.get("title3").get("top").value(), EPSILON);
+        assertEquals(275, nodeHashMap.get("title2").get("top").getValue(), EPSILON);
+        assertEquals(275, nodeHashMap.get("title3").get("top").getValue(), EPSILON);
 
-        assertEquals(420, nodeHashMap.get("thumb4").get("top").value(), EPSILON);
-        assertEquals(420, nodeHashMap.get("thumb5").get("top").value(), EPSILON);
+        assertEquals(420, nodeHashMap.get("thumb4").get("top").getValue(), EPSILON);
+        assertEquals(420, nodeHashMap.get("thumb5").get("top").getValue(), EPSILON);
 
-        assertEquals(485, nodeHashMap.get("title4").get("top").value(), EPSILON);
-        assertEquals(485, nodeHashMap.get("title5").get("top").value(), EPSILON);
+        assertEquals(485, nodeHashMap.get("title4").get("top").getValue(), EPSILON);
+        assertEquals(485, nodeHashMap.get("title5").get("top").getValue(), EPSILON);
 
     }
 
@@ -286,23 +286,23 @@ public class RealWorldTests {
 
         solver.solve();
 
-        assertEquals(20, nodeHashMap.get("thumb0").get("top").value(), EPSILON);
-        assertEquals(20, nodeHashMap.get("thumb1").get("top").value(), EPSILON);
+        assertEquals(20, nodeHashMap.get("thumb0").get("top").getValue(), EPSILON);
+        assertEquals(20, nodeHashMap.get("thumb1").get("top").getValue(), EPSILON);
 
-        assertEquals(85, nodeHashMap.get("title0").get("top").value(), EPSILON);
-        assertEquals(85, nodeHashMap.get("title1").get("top").value(), EPSILON);
+        assertEquals(85, nodeHashMap.get("title0").get("top").getValue(), EPSILON);
+        assertEquals(85, nodeHashMap.get("title1").get("top").getValue(), EPSILON);
 
-        assertEquals(210, nodeHashMap.get("thumb2").get("top").value(), EPSILON);
-        assertEquals(210, nodeHashMap.get("thumb3").get("top").value(), EPSILON);
+        assertEquals(210, nodeHashMap.get("thumb2").get("top").getValue(), EPSILON);
+        assertEquals(210, nodeHashMap.get("thumb3").get("top").getValue(), EPSILON);
 
-        assertEquals(275, nodeHashMap.get("title2").get("top").value(), EPSILON);
-        assertEquals(275, nodeHashMap.get("title3").get("top").value(), EPSILON);
+        assertEquals(275, nodeHashMap.get("title2").get("top").getValue(), EPSILON);
+        assertEquals(275, nodeHashMap.get("title3").get("top").getValue(), EPSILON);
 
-        assertEquals(420, nodeHashMap.get("thumb4").get("top").value(), EPSILON);
-        assertEquals(420, nodeHashMap.get("thumb5").get("top").value(), EPSILON);
+        assertEquals(420, nodeHashMap.get("thumb4").get("top").getValue(), EPSILON);
+        assertEquals(420, nodeHashMap.get("thumb5").get("top").getValue(), EPSILON);
 
-        assertEquals(485, nodeHashMap.get("title4").get("top").value(), EPSILON);
-        assertEquals(485, nodeHashMap.get("title5").get("top").value(), EPSILON);
+        assertEquals(485, nodeHashMap.get("title4").get("top").getValue(), EPSILON);
+        assertEquals(485, nodeHashMap.get("title5").get("top").getValue(), EPSILON);
 
     }
 
@@ -319,7 +319,7 @@ public class RealWorldTests {
         Iterator<Map.Entry<String, Variable>> it = variableHashMap.entrySet().iterator();
         while (it.hasNext()) {
             Map.Entry<String, Variable> pairs = it.next();
-            System.out.println(" " + pairs.getKey() + " = " + pairs.getValue().value() + " (address:" + pairs.getValue().hashCode() + ")");
+            System.out.println(" " + pairs.getKey() + " = " + pairs.getValue().getValue() + " (address:" + pairs.getValue().hashCode() + ")");
         }
     }
 

--- a/src/test/java/org/pybee/cassowary/test/Tests.java
+++ b/src/test/java/org/pybee/cassowary/test/Tests.java
@@ -1,9 +1,6 @@
 package org.pybee.cassowary.test;
 
-import java.util.Random;
-
 import org.pybee.cassowary.*;
-import org.junit.Assert;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -21,7 +18,7 @@ public class Tests {
         Constraint eq = new Constraint(x, Constraint.Operator.EQ, new Expression(y));
         //ClLinearEquation eq = new ClLinearEquation(x, new ClLinearExpression(y));
         solver.addConstraint(eq);
-        assertEquals(x.value(), y.value(), EPSILON);
+        assertEquals(x.getValue(), y.getValue(), EPSILON);
     }
 
     @Test
@@ -32,8 +29,8 @@ public class Tests {
 
         solver.addStay(x);
         solver.addStay(y);
-        assertEquals(5, x.value(), EPSILON);
-        assertEquals(10, y.value(), EPSILON);
+        assertEquals(5, x.getValue(), EPSILON);
+        assertEquals(10, y.getValue(), EPSILON);
     }
 
 
@@ -50,26 +47,26 @@ public class Tests {
         solver.addConstraint(c10);
         solver.addConstraint(c20);
 
-        assertEquals(10, x.value(), EPSILON);
+        assertEquals(10, x.getValue(), EPSILON);
 
         solver.removeConstraint(c10);
-        assertEquals(20, x.value(), EPSILON);
+        assertEquals(20, x.getValue(), EPSILON);
 
         solver.removeConstraint(c20);
-        assertEquals(100, x.value(), EPSILON);
+        assertEquals(100, x.getValue(), EPSILON);
 
         Constraint c10again = new Constraint(x, Constraint.Operator.LEQ, 10.0);
 
         solver.addConstraint(c10);
         solver.addConstraint(c10again);
 
-        assertEquals(10, x.value(), EPSILON);
+        assertEquals(10, x.getValue(), EPSILON);
 
         solver.removeConstraint(c10);
-        assertEquals(10, x.value(), EPSILON);
+        assertEquals(10, x.getValue(), EPSILON);
 
         solver.removeConstraint(c10again);
-        assertEquals(100, x.value(), EPSILON);
+        assertEquals(100, x.getValue(), EPSILON);
     }
 
 
@@ -89,25 +86,25 @@ public class Tests {
         solver.addConstraint(c10);
         solver.addConstraint(c20);
 
-        assertEquals(10, x.value(), EPSILON);
-        assertEquals(120, y.value(), EPSILON);
+        assertEquals(10, x.getValue(), EPSILON);
+        assertEquals(120, y.getValue(), EPSILON);
 
         solver.removeConstraint(c10);
-        assertEquals(20, x.value(), EPSILON);
-        assertEquals(120, y.value(), EPSILON);
+        assertEquals(20, x.getValue(), EPSILON);
+        assertEquals(120, y.getValue(), EPSILON);
 
         Constraint cxy = new Constraint(x.times(2.0), Constraint.Operator.EQ, y);
         solver.addConstraint(cxy);
-        assertEquals(20, x.value(), EPSILON);
-        assertEquals(40, y.value(), EPSILON);
+        assertEquals(20, x.getValue(), EPSILON);
+        assertEquals(40, y.getValue(), EPSILON);
 
         solver.removeConstraint(c20);
-        assertEquals(60, x.value(), EPSILON);
-        assertEquals(120, y.value(), EPSILON);
+        assertEquals(60, x.getValue(), EPSILON);
+        assertEquals(120, y.getValue(), EPSILON);
 
         solver.removeConstraint(cxy);
-        assertEquals(100, x.value(), EPSILON);
-        assertEquals(120, y.value(), EPSILON);
+        assertEquals(100, x.getValue(), EPSILON);
+        assertEquals(120, y.getValue(), EPSILON);
     }
 
     @Test
@@ -121,12 +118,12 @@ public class Tests {
         solver.addConstraint(new Constraint(x, Constraint.Operator.EQ, 10.0, Strength.WEAK));
         solver.addConstraint(new Constraint(y, Constraint.Operator.EQ, 10.0, Strength.WEAK));
 
-        if (Math.abs(x.value() - 10.0) < EPSILON) {
-            assertEquals(10, x.value(), EPSILON);
-            assertEquals(13, y.value(), EPSILON);
+        if (Math.abs(x.getValue() - 10.0) < EPSILON) {
+            assertEquals(10, x.getValue(), EPSILON);
+            assertEquals(13, y.getValue(), EPSILON);
         } else {
-            assertEquals(7, x.value(), EPSILON);
-            assertEquals(10, y.value(), EPSILON);
+            assertEquals(7, x.getValue(), EPSILON);
+            assertEquals(10, y.getValue(), EPSILON);
         }
     }
 
@@ -170,10 +167,10 @@ public class Tests {
         solver.suggestValue(y, 20);
         solver.resolve();
 
-        assertEquals(10, x.value(), EPSILON);
-        assertEquals(20, y.value(), EPSILON);
-        assertEquals(0, w.value(), EPSILON);
-        assertEquals(0, h.value(), EPSILON);
+        assertEquals(10, x.getValue(), EPSILON);
+        assertEquals(20, y.getValue(), EPSILON);
+        assertEquals(0, w.getValue(), EPSILON);
+        assertEquals(0, h.getValue(), EPSILON);
 
 
         solver.addEditVar(w);
@@ -184,18 +181,18 @@ public class Tests {
         solver.suggestValue(h, 40);
         solver.endEdit();
 
-        assertEquals(10, x.value(), EPSILON);
-        assertEquals(20, y.value(), EPSILON);
-        assertEquals(30, w.value(), EPSILON);
-        assertEquals(40, h.value(), EPSILON);
+        assertEquals(10, x.getValue(), EPSILON);
+        assertEquals(20, y.getValue(), EPSILON);
+        assertEquals(30, w.getValue(), EPSILON);
+        assertEquals(40, h.getValue(), EPSILON);
 
         solver.suggestValue(x, 50).suggestValue(y, 60).endEdit();
 
 
-        assertEquals(50, x.value(), EPSILON);
-        assertEquals(60, y.value(), EPSILON);
-        assertEquals(30, w.value(), EPSILON);
-        assertEquals(40, h.value(), EPSILON);
+        assertEquals(50, x.getValue(), EPSILON);
+        assertEquals(60, y.getValue(), EPSILON);
+        assertEquals(30, w.getValue(), EPSILON);
+        assertEquals(40, h.getValue(), EPSILON);
     }
 
 
@@ -222,10 +219,10 @@ public class Tests {
         solver.resolve();
         solver.solve();
 
-        assertEquals(10, x.value(), EPSILON);
-        assertEquals(20, y.value(), EPSILON);
-        assertEquals(0, w.value(), EPSILON);
-        assertEquals(0, h.value(), EPSILON);
+        assertEquals(10, x.getValue(), EPSILON);
+        assertEquals(20, y.getValue(), EPSILON);
+        assertEquals(0, w.getValue(), EPSILON);
+        assertEquals(0, h.getValue(), EPSILON);
 
         solver.addEditVar(w);
         solver.addEditVar(h);
@@ -237,18 +234,18 @@ public class Tests {
 
         solver.solve();
 
-        assertEquals(10, x.value(), EPSILON);
-        assertEquals(20, y.value(), EPSILON);
-        assertEquals(30, w.value(), EPSILON);
-        assertEquals(40, h.value(), EPSILON);
+        assertEquals(10, x.getValue(), EPSILON);
+        assertEquals(20, y.getValue(), EPSILON);
+        assertEquals(30, w.getValue(), EPSILON);
+        assertEquals(40, h.getValue(), EPSILON);
 
         solver.suggestValue(x, 50).suggestValue(y, 60).endEdit();
         solver.solve();
 
-        assertEquals(50, x.value(), EPSILON);
-        assertEquals(60, y.value(), EPSILON);
-        assertEquals(30, w.value(), EPSILON);
-        assertEquals(40, h.value(), EPSILON);
+        assertEquals(50, x.getValue(), EPSILON);
+        assertEquals(60, y.getValue(), EPSILON);
+        assertEquals(30, w.getValue(), EPSILON);
+        assertEquals(40, h.getValue(), EPSILON);
     }
 
     @Test
@@ -273,10 +270,10 @@ public class Tests {
         solver.resolve();
         solver.solve();
 
-        assertEquals(10, x.value(), EPSILON);
-        assertEquals(20, y.value(), EPSILON);
-        assertEquals(0, w.value(), EPSILON);
-        assertEquals(0, h.value(), EPSILON);
+        assertEquals(10, x.getValue(), EPSILON);
+        assertEquals(20, y.getValue(), EPSILON);
+        assertEquals(0, w.getValue(), EPSILON);
+        assertEquals(0, h.getValue(), EPSILON);
 
 
         solver.addEditVar(w, Strength.REQUIRED);
@@ -289,18 +286,18 @@ public class Tests {
 
         solver.solve();
 
-        assertEquals(10, x.value(), EPSILON);
-        assertEquals(20, y.value(), EPSILON);
-        assertEquals(30, w.value(), EPSILON);
-        assertEquals(40, h.value(), EPSILON);
+        assertEquals(10, x.getValue(), EPSILON);
+        assertEquals(20, y.getValue(), EPSILON);
+        assertEquals(30, w.getValue(), EPSILON);
+        assertEquals(40, h.getValue(), EPSILON);
 
         solver.suggestValue(x, 50).suggestValue(y, 60).endEdit();
         solver.solve();
 
-        assertEquals(50, x.value(), EPSILON);
-        assertEquals(60, y.value(), EPSILON);
-        assertEquals(30, w.value(), EPSILON);
-        assertEquals(40, h.value(), EPSILON);
+        assertEquals(50, x.getValue(), EPSILON);
+        assertEquals(60, y.getValue(), EPSILON);
+        assertEquals(30, w.getValue(), EPSILON);
+        assertEquals(40, h.getValue(), EPSILON);
     }
 
     @Test(expected = RequiredFailure.class)

--- a/src/test/java/org/pybee/cassowary/test/TimingTests.java
+++ b/src/test/java/org/pybee/cassowary/test/TimingTests.java
@@ -102,7 +102,7 @@ public class TimingTests {
 
         // FIXGJB start = Timer.now();
         for (int m = 0; m < RESOLVE_COUNT; m++) {
-            solver.resolve(rgpclv[e1Index].value() * 1.001, rgpclv[e2Index].value() * 1.001);
+            solver.resolve(rgpclv[e1Index].getValue() * 1.001, rgpclv[e2Index].getValue() * 1.001);
         }
 
         System.out.println("done resolves -- now removing constraints");

--- a/src/test/java/org/pybee/cassowary/test/benchmark/Benchmarks.java
+++ b/src/test/java/org/pybee/cassowary/test/benchmark/Benchmarks.java
@@ -63,7 +63,7 @@ public class Benchmarks {
     }
 
     private static String getVariableName(int number) {
-        return "variable" + number;
+        return "getVariable" + number;
     }
 
     public static void main(String [ ] args) throws CassowaryError {


### PR DESCRIPTION
All getters are prefixed with get. All method names are in camel case, not snake case.

There is also a small change to `build.gradle` that allows me to build without defining `bintray_user` and `bintray_api_key`